### PR TITLE
feat(notification): 알림 서비스 초기 구현

### DIFF
--- a/notification-service/Dockerfile
+++ b/notification-service/Dockerfile
@@ -1,0 +1,42 @@
+# Multi-stage build for notification-service
+FROM eclipse-temurin:21-jdk-jammy as builder
+
+WORKDIR /app
+
+# Gradle Wrapper 및 설정 파일 복사
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle .
+COPY settings.gradle .
+
+# 소스 코드 복사 및 빌드
+COPY src src
+RUN ./gradlew bootJar --no-daemon
+
+# 실행 이미지
+FROM eclipse-temurin:21-jre-jammy
+
+WORKDIR /app
+
+# 보안을 위한 non-root 사용자 생성
+RUN groupadd -r notification && useradd -r -g notification notification
+
+# 빌드된 JAR 파일 복사
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+# 파일 권한 설정
+RUN chown notification:notification app.jar
+
+# 비루트 사용자로 전환
+USER notification
+
+# 헬스체크
+HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+  CMD curl -f http://localhost:8084/actuator/health || exit 1
+
+# 포트 노출
+EXPOSE 8084
+
+# 애플리케이션 실행
+ENTRYPOINT ["java", "-jar", "app.jar"]
+

--- a/notification-service/build.gradle
+++ b/notification-service/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.kafka:spring-kafka'
 	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 	implementation 'io.micrometer:micrometer-registry-prometheus'

--- a/notification-service/src/main/java/org/example/notificationservice/NotificationServiceApplication.java
+++ b/notification-service/src/main/java/org/example/notificationservice/NotificationServiceApplication.java
@@ -1,13 +1,22 @@
 package org.example.notificationservice;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+@Slf4j
 @SpringBootApplication
+@EnableKafka
+@EnableRetry
+@EnableTransactionManagement
 public class NotificationServiceApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(NotificationServiceApplication.class, args);
-	}
-
+    public static void main(String[] args) {
+        log.info("Starting Notification Service Application...");
+        SpringApplication.run(NotificationServiceApplication.class, args);
+        log.info("Notification Service Application started successfully!");
+    }
 }

--- a/notification-service/src/main/java/org/example/notificationservice/config/CacheConfig.java
+++ b/notification-service/src/main/java/org/example/notificationservice/config/CacheConfig.java
@@ -1,0 +1,29 @@
+package org.example.notificationservice.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Slf4j
+@Configuration
+@EnableCaching
+public class CacheConfig {
+    
+    @Bean
+    public CacheManager cacheManager() {
+        ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager();
+        
+        // 캐시 이름 설정
+        cacheManager.setCacheNames(java.util.Arrays.asList(
+            "stockNames"
+        ));
+        
+        log.info("Cache Manager initialized for notification service");
+        
+        return cacheManager;
+    }
+}
+

--- a/notification-service/src/main/java/org/example/notificationservice/config/KafkaConfig.java
+++ b/notification-service/src/main/java/org/example/notificationservice/config/KafkaConfig.java
@@ -1,0 +1,107 @@
+package org.example.notificationservice.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.listener.ContainerProperties;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+    
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+    
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+    
+    @Value("${spring.kafka.listener.concurrency:2}")
+    private int concurrency;
+    
+    // Consumer Configuration
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        
+        configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        
+        // 알림 서비스 최적화 설정
+        configProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+        configProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        configProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 100);
+        configProps.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, 1);
+        configProps.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, 500);
+        
+        configProps.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 30000);
+        configProps.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 3000);
+        configProps.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 300000);
+        
+        log.info("Kafka Consumer configuration initialized for notification service - Bootstrap servers: {}", bootstrapServers);
+        
+        return new DefaultKafkaConsumerFactory<>(configProps);
+    }
+    
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = 
+            new ConcurrentKafkaListenerContainerFactory<>();
+        
+        factory.setConsumerFactory(consumerFactory());
+        factory.setConcurrency(concurrency);
+        
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        factory.getContainerProperties().setPollTimeout(3000);
+        
+        // 에러 핸들링
+        factory.setCommonErrorHandler(new org.springframework.kafka.listener.DefaultErrorHandler());
+        
+        log.info("Kafka Listener Container Factory initialized for notification service with concurrency: {}", concurrency);
+        
+        return factory;
+    }
+    
+    // Producer Configuration
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        
+        // 신뢰성 설정
+        configProps.put(ProducerConfig.ACKS_CONFIG, "all");
+        configProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        configProps.put(ProducerConfig.RETRIES_CONFIG, 3);
+        
+        // 성능 설정
+        configProps.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384);
+        configProps.put(ProducerConfig.LINGER_MS_CONFIG, 5);
+        configProps.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
+        
+        log.info("Kafka Producer configuration initialized for notification service");
+        
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+    
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}
+

--- a/notification-service/src/main/java/org/example/notificationservice/consumer/NotificationConsumer.java
+++ b/notification-service/src/main/java/org/example/notificationservice/consumer/NotificationConsumer.java
@@ -1,0 +1,66 @@
+package org.example.notificationservice.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.notificationservice.dto.NotificationMessage;
+import org.example.notificationservice.service.NotificationDeliveryService;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationConsumer {
+    
+    private final NotificationDeliveryService notificationDeliveryService;
+    private final ObjectMapper objectMapper;
+    
+    @KafkaListener(
+        topics = "${app.kafka.topics.notification-alerts:notification-alerts}",
+        groupId = "notification-delivery-group",
+        containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void consumeNotificationMessage(
+        @Payload String message,
+        @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+        @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+        @Header(KafkaHeaders.RECEIVED_KEY) String key,
+        @Header(KafkaHeaders.OFFSET) long offset,
+        Acknowledgment acknowledgment
+    ) {
+        try {
+            log.debug("Received notification message - Topic: {}, Partition: {}, Key: {}, Offset: {}", 
+                topic, partition, key, offset);
+            
+            // JSON 메시지 파싱
+            NotificationMessage notification = objectMapper.readValue(message, NotificationMessage.class);
+            
+            // 알림 전송 처리
+            boolean deliverySuccess = notificationDeliveryService.deliverNotification(notification);
+            
+            if (deliverySuccess) {
+                log.info("Notification delivered successfully - ID: {}, User: {}, Stock: {}", 
+                    notification.getNotificationId(), notification.getUserId(), notification.getStockCode());
+            } else {
+                log.warn("Notification delivery failed - ID: {}, User: {}, Stock: {}", 
+                    notification.getNotificationId(), notification.getUserId(), notification.getStockCode());
+            }
+            
+            // 수동 커밋 (성공/실패 관계없이 - 재시도는 별도 로직에서 처리)
+            acknowledgment.acknowledge();
+            
+        } catch (Exception e) {
+            log.error("Error processing notification message - Topic: {}, Key: {}, Message: {}", 
+                topic, key, message, e);
+            
+            // 파싱 에러 등은 재처리 불가능하므로 acknowledge
+            acknowledgment.acknowledge();
+        }
+    }
+}
+

--- a/notification-service/src/main/java/org/example/notificationservice/consumer/QuoteStreamConsumer.java
+++ b/notification-service/src/main/java/org/example/notificationservice/consumer/QuoteStreamConsumer.java
@@ -1,0 +1,65 @@
+package org.example.notificationservice.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.notificationservice.dto.KisQuoteMessage;
+import org.example.notificationservice.service.ConditionEvaluationService;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class QuoteStreamConsumer {
+    
+    private final ConditionEvaluationService conditionEvaluationService;
+    private final ObjectMapper objectMapper;
+    
+    @KafkaListener(
+        topics = "${app.kafka.topics.quote-stream:quote-stream}",
+        groupId = "${spring.kafka.consumer.group-id}",
+        containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void consumeQuoteMessage(
+        @Payload String message,
+        @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+        @Header(KafkaHeaders.RECEIVED_PARTITION) int partition,
+        @Header(KafkaHeaders.RECEIVED_KEY) String key,
+        @Header(KafkaHeaders.OFFSET) long offset,
+        Acknowledgment acknowledgment
+    ) {
+        try {
+            log.trace("Received quote message for condition evaluation - Topic: {}, Key: {}, Offset: {}", 
+                topic, key, offset);
+            
+            // JSON 메시지 파싱
+            KisQuoteMessage quoteMessage = objectMapper.readValue(message, KisQuoteMessage.class);
+            
+            // 조건 평가 수행
+            conditionEvaluationService.evaluateQuoteConditions(
+                quoteMessage.getTrKey(),
+                quoteMessage.getPriceAsBigDecimal(),
+                quoteMessage.getVolumeAsLong(),
+                quoteMessage.getChangeRateAsBigDecimal()
+            );
+            
+            // 수동 커밋
+            acknowledgment.acknowledge();
+            
+            log.trace("Quote message processed for condition evaluation - Stock: {}", quoteMessage.getTrKey());
+            
+        } catch (Exception e) {
+            log.error("Error processing quote message for condition evaluation - Topic: {}, Key: {}, Message: {}", 
+                topic, key, message, e);
+            
+            // 에러 발생 시에도 acknowledge (알림은 최대한 실시간성 중시)
+            acknowledgment.acknowledge();
+        }
+    }
+}
+

--- a/notification-service/src/main/java/org/example/notificationservice/controller/NotificationController.java
+++ b/notification-service/src/main/java/org/example/notificationservice/controller/NotificationController.java
@@ -1,0 +1,169 @@
+package org.example.notificationservice.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.notificationservice.dto.CreateConditionRequest;
+import org.example.notificationservice.entity.NotificationCondition;
+import org.example.notificationservice.entity.NotificationHistory;
+import org.example.notificationservice.service.ConditionEvaluationService;
+import org.example.notificationservice.service.NotificationConditionService;
+import org.example.notificationservice.service.NotificationDeliveryService;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+    
+    private final NotificationConditionService conditionService;
+    private final ConditionEvaluationService evaluationService;
+    private final NotificationDeliveryService deliveryService;
+    
+    /**
+     * 알림 조건 생성
+     */
+    @PostMapping("/conditions")
+    public ResponseEntity<NotificationCondition> createCondition(@RequestBody CreateConditionRequest request) {
+        try {
+            NotificationCondition condition = conditionService.createCondition(request);
+            log.info("Notification condition created - ID: {}, User: {}, Stock: {}", 
+                condition.getId(), condition.getUserId(), condition.getStockCode());
+            return ResponseEntity.ok(condition);
+        } catch (Exception e) {
+            log.error("Error creating notification condition", e);
+            return ResponseEntity.badRequest().build();
+        }
+    }
+    
+    /**
+     * 사용자별 알림 조건 조회
+     */
+    @GetMapping("/conditions/user/{userId}")
+    public ResponseEntity<List<NotificationCondition>> getUserConditions(@PathVariable String userId) {
+        List<NotificationCondition> conditions = conditionService.getUserConditions(userId);
+        return ResponseEntity.ok(conditions);
+    }
+    
+    /**
+     * 활성화된 알림 조건 조회
+     */
+    @GetMapping("/conditions/user/{userId}/active")
+    public ResponseEntity<List<NotificationCondition>> getUserActiveConditions(@PathVariable String userId) {
+        List<NotificationCondition> conditions = conditionService.getUserActiveConditions(userId);
+        return ResponseEntity.ok(conditions);
+    }
+    
+    /**
+     * 알림 조건 수정
+     */
+    @PutMapping("/conditions/{conditionId}")
+    public ResponseEntity<NotificationCondition> updateCondition(
+        @PathVariable Long conditionId,
+        @RequestBody CreateConditionRequest request
+    ) {
+        try {
+            NotificationCondition condition = conditionService.updateCondition(conditionId, request);
+            return ResponseEntity.ok(condition);
+        } catch (Exception e) {
+            log.error("Error updating notification condition - ID: {}", conditionId, e);
+            return ResponseEntity.badRequest().build();
+        }
+    }
+    
+    /**
+     * 알림 조건 삭제
+     */
+    @DeleteMapping("/conditions/{conditionId}")
+    public ResponseEntity<Void> deleteCondition(@PathVariable Long conditionId) {
+        try {
+            conditionService.deleteCondition(conditionId);
+            return ResponseEntity.noContent().build();
+        } catch (Exception e) {
+            log.error("Error deleting notification condition - ID: {}", conditionId, e);
+            return ResponseEntity.badRequest().build();
+        }
+    }
+    
+    /**
+     * 알림 조건 활성화/비활성화
+     */
+    @PatchMapping("/conditions/{conditionId}/toggle")
+    public ResponseEntity<NotificationCondition> toggleCondition(@PathVariable Long conditionId) {
+        try {
+            NotificationCondition condition = conditionService.toggleCondition(conditionId);
+            return ResponseEntity.ok(condition);
+        } catch (Exception e) {
+            log.error("Error toggling notification condition - ID: {}", conditionId, e);
+            return ResponseEntity.badRequest().build();
+        }
+    }
+    
+    /**
+     * 알림 이력 조회
+     */
+    @GetMapping("/history/user/{userId}")
+    public ResponseEntity<List<NotificationHistory>> getUserNotificationHistory(
+        @PathVariable String userId,
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "20") int size
+    ) {
+        List<NotificationHistory> history = conditionService.getUserNotificationHistory(userId, PageRequest.of(page, size));
+        return ResponseEntity.ok(history);
+    }
+    
+    /**
+     * 종목별 알림 이력 조회
+     */
+    @GetMapping("/history/stock/{stockCode}")
+    public ResponseEntity<List<NotificationHistory>> getStockNotificationHistory(@PathVariable String stockCode) {
+        List<NotificationHistory> history = conditionService.getStockNotificationHistory(stockCode);
+        return ResponseEntity.ok(history);
+    }
+    
+    /**
+     * 알림 서비스 통계
+     */
+    @GetMapping("/stats")
+    public ResponseEntity<Map<String, Object>> getNotificationStats() {
+        Map<String, Object> stats = new HashMap<>();
+        
+        // 조건 평가 통계
+        ConditionEvaluationService.ConditionEvaluationStats evalStats = evaluationService.getEvaluationStats();
+        stats.put("evaluation", evalStats);
+        
+        // 전송 통계
+        NotificationDeliveryService.DeliveryStats deliveryStats = deliveryService.getDeliveryStats();
+        stats.put("delivery", deliveryStats);
+        
+        stats.put("timestamp", LocalDateTime.now());
+        
+        return ResponseEntity.ok(stats);
+    }
+    
+    /**
+     * 헬스체크
+     */
+    @GetMapping("/health")
+    public ResponseEntity<Map<String, Object>> health() {
+        Map<String, Object> health = new HashMap<>();
+        health.put("status", "UP");
+        health.put("service", "notification-service");
+        health.put("timestamp", LocalDateTime.now());
+        
+        // 간단한 통계 포함
+        ConditionEvaluationService.ConditionEvaluationStats stats = evaluationService.getEvaluationStats();
+        health.put("activeConditions", stats.getTotalActiveConditions());
+        health.put("pendingNotifications", stats.getPendingNotifications());
+        
+        return ResponseEntity.ok(health);
+    }
+}

--- a/notification-service/src/main/java/org/example/notificationservice/dto/CreateConditionRequest.java
+++ b/notification-service/src/main/java/org/example/notificationservice/dto/CreateConditionRequest.java
@@ -1,0 +1,41 @@
+package org.example.notificationservice.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.example.notificationservice.entity.NotificationCondition;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateConditionRequest {
+    
+    private String userId;
+    
+    private String stockCode;
+    
+    private NotificationCondition.ConditionType conditionType;
+    
+    private BigDecimal targetValue;
+    
+    private String description;
+    
+    /**
+     * Entity로 변환
+     */
+    public NotificationCondition toEntity() {
+        return NotificationCondition.builder()
+            .userId(userId)
+            .stockCode(stockCode)
+            .conditionType(conditionType)
+            .targetValue(targetValue)
+            .description(description)
+            .isActive(true)
+            .build();
+    }
+}

--- a/notification-service/src/main/java/org/example/notificationservice/dto/KisQuoteMessage.java
+++ b/notification-service/src/main/java/org/example/notificationservice/dto/KisQuoteMessage.java
@@ -1,0 +1,76 @@
+package org.example.notificationservice.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KisQuoteMessage {
+    
+    @JsonProperty("tr_id")
+    private String trId;
+    
+    @JsonProperty("tr_key")
+    private String trKey;
+    
+    @JsonProperty("timestamp")
+    private String timestamp;
+    
+    @JsonProperty("price")
+    private String price;
+    
+    @JsonProperty("volume")
+    private String volume;
+    
+    @JsonProperty("change_amount")
+    private String changeAmount;
+    
+    @JsonProperty("change_rate")
+    private String changeRate;
+    
+    @JsonProperty("high_price")
+    private String highPrice;
+    
+    @JsonProperty("low_price")
+    private String lowPrice;
+    
+    @JsonProperty("open_price")
+    private String openPrice;
+    
+    // 편의 메서드들
+    public BigDecimal getPriceAsBigDecimal() {
+        return price != null ? new BigDecimal(price) : BigDecimal.ZERO;
+    }
+    
+    public Long getVolumeAsLong() {
+        return volume != null ? Long.parseLong(volume) : 0L;
+    }
+    
+    public BigDecimal getChangeAmountAsBigDecimal() {
+        return changeAmount != null ? new BigDecimal(changeAmount) : BigDecimal.ZERO;
+    }
+    
+    public BigDecimal getChangeRateAsBigDecimal() {
+        return changeRate != null ? new BigDecimal(changeRate) : BigDecimal.ZERO;
+    }
+    
+    public BigDecimal getHighPriceAsBigDecimal() {
+        return highPrice != null ? new BigDecimal(highPrice) : BigDecimal.ZERO;
+    }
+    
+    public BigDecimal getLowPriceAsBigDecimal() {
+        return lowPrice != null ? new BigDecimal(lowPrice) : BigDecimal.ZERO;
+    }
+    
+    public BigDecimal getOpenPriceAsBigDecimal() {
+        return openPrice != null ? new BigDecimal(openPrice) : BigDecimal.ZERO;
+    }
+}
+

--- a/notification-service/src/main/java/org/example/notificationservice/dto/NotificationMessage.java
+++ b/notification-service/src/main/java/org/example/notificationservice/dto/NotificationMessage.java
@@ -1,0 +1,153 @@
+package org.example.notificationservice.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.example.notificationservice.entity.NotificationCondition;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationMessage {
+    
+    @JsonProperty("notification_id")
+    private Long notificationId;
+    
+    @JsonProperty("user_id")
+    private String userId;
+    
+    @JsonProperty("stock_code")
+    private String stockCode;
+    
+    @JsonProperty("stock_name")
+    private String stockName;
+    
+    @JsonProperty("condition_type")
+    private NotificationCondition.ConditionType conditionType;
+    
+    @JsonProperty("target_value")
+    private BigDecimal targetValue;
+    
+    @JsonProperty("triggered_value")
+    private BigDecimal triggeredValue;
+    
+    @JsonProperty("message")
+    private String message;
+    
+    @JsonProperty("triggered_at")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime triggeredAt;
+    
+    @JsonProperty("priority")
+    @Builder.Default
+    private Priority priority = Priority.NORMAL;
+    
+    @JsonProperty("channel")
+    @Builder.Default
+    private NotificationChannel channel = NotificationChannel.PUSH;
+    
+    public enum Priority {
+        LOW, NORMAL, HIGH, URGENT
+    }
+    
+    public enum NotificationChannel {
+        PUSH,    // 푸시 알림
+        EMAIL,   // 이메일
+        SMS,     // SMS
+        WEBHOOK  // 웹훅
+    }
+    
+    /**
+     * 알림 메시지 생성 헬퍼 메서드
+     */
+    public static NotificationMessage createPriceAlert(
+        String userId, 
+        String stockCode, 
+        String stockName,
+        NotificationCondition.ConditionType conditionType,
+        BigDecimal targetValue,
+        BigDecimal currentValue
+    ) {
+        String message = generateMessage(stockName, conditionType, targetValue, currentValue);
+        Priority priority = determinePriority(conditionType, targetValue, currentValue);
+        
+        return NotificationMessage.builder()
+            .userId(userId)
+            .stockCode(stockCode)
+            .stockName(stockName)
+            .conditionType(conditionType)
+            .targetValue(targetValue)
+            .triggeredValue(currentValue)
+            .message(message)
+            .triggeredAt(LocalDateTime.now())
+            .priority(priority)
+            .channel(NotificationChannel.PUSH)
+            .build();
+    }
+    
+    /**
+     * 알림 메시지 생성
+     */
+    private static String generateMessage(
+        String stockName, 
+        NotificationCondition.ConditionType conditionType,
+        BigDecimal targetValue,
+        BigDecimal currentValue
+    ) {
+        switch (conditionType) {
+            case PRICE_ABOVE:
+                return String.format("%s이 목표가 %,.0f원을 돌파했습니다! (현재가: %,.0f원)", 
+                    stockName, targetValue, currentValue);
+            case PRICE_BELOW:
+                return String.format("%s이 목표가 %,.0f원 아래로 떨어졌습니다! (현재가: %,.0f원)", 
+                    stockName, targetValue, currentValue);
+            case VOLUME_ABOVE:
+                return String.format("%s에서 거래량이 급증했습니다! (목표: %,.0f, 현재: %,.0f)", 
+                    stockName, targetValue, currentValue);
+            case CHANGE_RATE_ABOVE:
+                return String.format("%s이 급상승했습니다! (목표: %,.2f%%, 현재: %,.2f%%)", 
+                    stockName, targetValue, currentValue);
+            case CHANGE_RATE_BELOW:
+                return String.format("%s이 급하락했습니다! (목표: %,.2f%%, 현재: %,.2f%%)", 
+                    stockName, targetValue, currentValue);
+            default:
+                return String.format("%s 알림이 발생했습니다.", stockName);
+        }
+    }
+    
+    /**
+     * 우선순위 결정
+     */
+    private static Priority determinePriority(
+        NotificationCondition.ConditionType conditionType,
+        BigDecimal targetValue,
+        BigDecimal currentValue
+    ) {
+        // 변동률 기반 급상승/급하락은 긴급
+        if (conditionType == NotificationCondition.ConditionType.CHANGE_RATE_ABOVE ||
+            conditionType == NotificationCondition.ConditionType.CHANGE_RATE_BELOW) {
+            
+            BigDecimal changeRate = currentValue.abs();
+            if (changeRate.compareTo(BigDecimal.valueOf(10)) >= 0) {
+                return Priority.URGENT;
+            } else if (changeRate.compareTo(BigDecimal.valueOf(5)) >= 0) {
+                return Priority.HIGH;
+            }
+        }
+        
+        // 거래량 급증은 높은 우선순위
+        if (conditionType == NotificationCondition.ConditionType.VOLUME_ABOVE) {
+            return Priority.HIGH;
+        }
+        
+        return Priority.NORMAL;
+    }
+}
+

--- a/notification-service/src/main/java/org/example/notificationservice/entity/NotificationCondition.java
+++ b/notification-service/src/main/java/org/example/notificationservice/entity/NotificationCondition.java
@@ -1,0 +1,122 @@
+package org.example.notificationservice.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notification_conditions", indexes = {
+    @Index(name = "idx_user_id", columnList = "user_id"),
+    @Index(name = "idx_stock_code_active", columnList = "stock_code, is_active"),
+    @Index(name = "idx_condition_type", columnList = "condition_type"),
+    @Index(name = "idx_is_active", columnList = "is_active")
+})
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationCondition {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "user_id", length = 50, nullable = false)
+    private String userId;
+    
+    @Column(name = "stock_code", length = 10, nullable = false)
+    private String stockCode;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "condition_type", length = 20, nullable = false)
+    private ConditionType conditionType;
+    
+    @Column(name = "target_value", precision = 15, scale = 2, nullable = false)
+    private BigDecimal targetValue;
+    
+    @Column(name = "current_value", precision = 15, scale = 2)
+    private BigDecimal currentValue;
+    
+    @Column(name = "is_active", nullable = false)
+    @Builder.Default
+    private Boolean isActive = true;
+    
+    @Column(name = "triggered_at")
+    private LocalDateTime triggeredAt;
+    
+    @Column(name = "description", length = 255)
+    private String description;
+    
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+    
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+    
+    public enum ConditionType {
+        PRICE_ABOVE("가격 상승"),      // 목표가 이상
+        PRICE_BELOW("가격 하락"),      // 목표가 이하
+        VOLUME_ABOVE("거래량 급증"),   // 거래량 이상
+        CHANGE_RATE_ABOVE("급상승"),   // 변동률 이상
+        CHANGE_RATE_BELOW("급하락");   // 변동률 이하
+        
+        private final String description;
+        
+        ConditionType(String description) {
+            this.description = description;
+        }
+        
+        public String getDescription() {
+            return description;
+        }
+    }
+    
+    /**
+     * 조건이 충족되었는지 확인
+     */
+    public boolean isConditionMet(BigDecimal currentPrice, Long currentVolume, BigDecimal changeRate) {
+        switch (conditionType) {
+            case PRICE_ABOVE:
+                return currentPrice.compareTo(targetValue) >= 0;
+            case PRICE_BELOW:
+                return currentPrice.compareTo(targetValue) <= 0;
+            case VOLUME_ABOVE:
+                return currentVolume != null && 
+                       BigDecimal.valueOf(currentVolume).compareTo(targetValue) >= 0;
+            case CHANGE_RATE_ABOVE:
+                return changeRate != null && changeRate.compareTo(targetValue) >= 0;
+            case CHANGE_RATE_BELOW:
+                return changeRate != null && changeRate.compareTo(targetValue) <= 0;
+            default:
+                return false;
+        }
+    }
+    
+    /**
+     * 조건 트리거 처리
+     */
+    public void trigger(BigDecimal currentValue) {
+        this.currentValue = currentValue;
+        this.triggeredAt = LocalDateTime.now();
+        this.isActive = false; // 한 번 트리거되면 비활성화
+    }
+    
+    /**
+     * 조건 재활성화
+     */
+    public void reactivate() {
+        this.isActive = true;
+        this.triggeredAt = null;
+        this.currentValue = null;
+    }
+}
+

--- a/notification-service/src/main/java/org/example/notificationservice/entity/NotificationHistory.java
+++ b/notification-service/src/main/java/org/example/notificationservice/entity/NotificationHistory.java
@@ -1,0 +1,117 @@
+package org.example.notificationservice.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notification_history", indexes = {
+    @Index(name = "idx_user_id_created", columnList = "user_id, created_at"),
+    @Index(name = "idx_stock_code_created", columnList = "stock_code, created_at"),
+    @Index(name = "idx_condition_id", columnList = "condition_id"),
+    @Index(name = "idx_status", columnList = "status")
+})
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NotificationHistory {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "user_id", length = 50, nullable = false)
+    private String userId;
+    
+    @Column(name = "stock_code", length = 10, nullable = false)
+    private String stockCode;
+    
+    @Column(name = "condition_id", nullable = false)
+    private Long conditionId;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "condition_type", length = 20, nullable = false)
+    private NotificationCondition.ConditionType conditionType;
+    
+    @Column(name = "target_value", precision = 15, scale = 2, nullable = false)
+    private BigDecimal targetValue;
+    
+    @Column(name = "triggered_value", precision = 15, scale = 2, nullable = false)
+    private BigDecimal triggeredValue;
+    
+    @Column(name = "message", length = 500, nullable = false)
+    private String message;
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 20, nullable = false)
+    @Builder.Default
+    private NotificationStatus status = NotificationStatus.PENDING;
+    
+    @Column(name = "retry_count")
+    @Builder.Default
+    private Integer retryCount = 0;
+    
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+    
+    @Column(name = "error_message", length = 1000)
+    private String errorMessage;
+    
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "condition_id", insertable = false, updatable = false)
+    private NotificationCondition condition;
+    
+    public enum NotificationStatus {
+        PENDING("대기중"),
+        SENT("전송완료"),
+        FAILED("전송실패"),
+        RETRY("재시도중");
+        
+        private final String description;
+        
+        NotificationStatus(String description) {
+            this.description = description;
+        }
+        
+        public String getDescription() {
+            return description;
+        }
+    }
+    
+    /**
+     * 알림 전송 성공 처리
+     */
+    public void markAsSent() {
+        this.status = NotificationStatus.SENT;
+        this.sentAt = LocalDateTime.now();
+        this.errorMessage = null;
+    }
+    
+    /**
+     * 알림 전송 실패 처리
+     */
+    public void markAsFailed(String errorMessage) {
+        this.status = NotificationStatus.FAILED;
+        this.errorMessage = errorMessage;
+    }
+    
+    /**
+     * 재시도 처리
+     */
+    public void incrementRetry() {
+        this.retryCount++;
+        this.status = NotificationStatus.RETRY;
+    }
+}
+

--- a/notification-service/src/main/java/org/example/notificationservice/entity/Stock.java
+++ b/notification-service/src/main/java/org/example/notificationservice/entity/Stock.java
@@ -1,0 +1,39 @@
+package org.example.notificationservice.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "stocks")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Stock {
+    
+    @Id
+    @Column(name = "stock_code", length = 10)
+    private String stockCode;
+    
+    @Column(name = "stock_name", length = 100, nullable = false)
+    private String stockName;
+    
+    @Column(name = "market_type", length = 10, nullable = false)
+    private String marketType;
+    
+    @CreationTimestamp
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+    
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}
+

--- a/notification-service/src/main/java/org/example/notificationservice/repository/NotificationConditionRepository.java
+++ b/notification-service/src/main/java/org/example/notificationservice/repository/NotificationConditionRepository.java
@@ -1,0 +1,62 @@
+package org.example.notificationservice.repository;
+
+import org.example.notificationservice.entity.NotificationCondition;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NotificationConditionRepository extends JpaRepository<NotificationCondition, Long> {
+    
+    /**
+     * 활성화된 조건들 조회
+     */
+    List<NotificationCondition> findByIsActiveTrue();
+    
+    /**
+     * 특정 종목의 활성화된 조건들 조회
+     */
+    List<NotificationCondition> findByStockCodeAndIsActiveTrue(String stockCode);
+    
+    /**
+     * 특정 사용자의 조건들 조회
+     */
+    List<NotificationCondition> findByUserIdOrderByCreatedAtDesc(String userId);
+    
+    /**
+     * 특정 사용자의 활성화된 조건들 조회
+     */
+    List<NotificationCondition> findByUserIdAndIsActiveTrueOrderByCreatedAtDesc(String userId);
+    
+    /**
+     * 특정 사용자의 특정 종목 조건들 조회
+     */
+    List<NotificationCondition> findByUserIdAndStockCodeOrderByCreatedAtDesc(String userId, String stockCode);
+    
+    /**
+     * 조건 타입별 활성화된 조건들 조회
+     */
+    List<NotificationCondition> findByConditionTypeAndIsActiveTrue(NotificationCondition.ConditionType conditionType);
+    
+    /**
+     * 배치 처리용 - 페이지네이션으로 활성화된 조건들 조회
+     */
+    @Query("SELECT nc FROM NotificationCondition nc WHERE nc.isActive = true ORDER BY nc.stockCode, nc.id")
+    List<NotificationCondition> findActiveConditionsBatch(Pageable pageable);
+    
+    /**
+     * 특정 종목의 조건 수 조회
+     */
+    @Query("SELECT COUNT(nc) FROM NotificationCondition nc WHERE nc.stockCode = :stockCode AND nc.isActive = true")
+    long countActiveConditionsByStock(@Param("stockCode") String stockCode);
+    
+    /**
+     * 전체 활성화된 조건 수 조회
+     */
+    long countByIsActiveTrue();
+}
+

--- a/notification-service/src/main/java/org/example/notificationservice/repository/NotificationHistoryRepository.java
+++ b/notification-service/src/main/java/org/example/notificationservice/repository/NotificationHistoryRepository.java
@@ -1,0 +1,73 @@
+package org.example.notificationservice.repository;
+
+import org.example.notificationservice.entity.NotificationHistory;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface NotificationHistoryRepository extends JpaRepository<NotificationHistory, Long> {
+    
+    /**
+     * 특정 사용자의 알림 이력 조회 (최신순)
+     */
+    List<NotificationHistory> findByUserIdOrderByCreatedAtDesc(String userId);
+    
+    /**
+     * 특정 사용자의 알림 이력 조회 (페이지네이션)
+     */
+    List<NotificationHistory> findByUserIdOrderByCreatedAtDesc(String userId, Pageable pageable);
+    
+    /**
+     * 특정 종목의 알림 이력 조회
+     */
+    List<NotificationHistory> findByStockCodeOrderByCreatedAtDesc(String stockCode);
+    
+    /**
+     * 실패한 알림들 조회 (재시도 대상)
+     */
+    List<NotificationHistory> findByStatusAndRetryCountLessThan(
+        NotificationHistory.NotificationStatus status, 
+        Integer maxRetryCount
+    );
+    
+    /**
+     * 특정 기간의 알림 이력 조회
+     */
+    @Query("SELECT nh FROM NotificationHistory nh WHERE nh.createdAt BETWEEN :startTime AND :endTime ORDER BY nh.createdAt DESC")
+    List<NotificationHistory> findByCreatedAtBetween(
+        @Param("startTime") LocalDateTime startTime, 
+        @Param("endTime") LocalDateTime endTime
+    );
+    
+    /**
+     * 특정 조건의 알림 이력 조회
+     */
+    List<NotificationHistory> findByConditionIdOrderByCreatedAtDesc(Long conditionId);
+    
+    /**
+     * 상태별 알림 수 조회
+     */
+    long countByStatus(NotificationHistory.NotificationStatus status);
+    
+    /**
+     * 특정 기간의 상태별 알림 수 조회
+     */
+    @Query("SELECT COUNT(nh) FROM NotificationHistory nh WHERE nh.status = :status AND nh.createdAt >= :afterTime")
+    long countByStatusAndCreatedAtAfter(
+        @Param("status") NotificationHistory.NotificationStatus status, 
+        @Param("afterTime") LocalDateTime afterTime
+    );
+    
+    /**
+     * 오래된 이력 정리용 - 특정 기간 이전 데이터 조회
+     */
+    @Query("SELECT nh FROM NotificationHistory nh WHERE nh.createdAt < :beforeTime")
+    List<NotificationHistory> findOldHistories(@Param("beforeTime") LocalDateTime beforeTime, Pageable pageable);
+}
+

--- a/notification-service/src/main/java/org/example/notificationservice/repository/StockRepository.java
+++ b/notification-service/src/main/java/org/example/notificationservice/repository/StockRepository.java
@@ -1,0 +1,14 @@
+package org.example.notificationservice.repository;
+
+import org.example.notificationservice.entity.Stock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface StockRepository extends JpaRepository<Stock, String> {
+    
+    Optional<Stock> findByStockCode(String stockCode);
+}
+

--- a/notification-service/src/main/java/org/example/notificationservice/service/ConditionEvaluationService.java
+++ b/notification-service/src/main/java/org/example/notificationservice/service/ConditionEvaluationService.java
@@ -1,0 +1,227 @@
+package org.example.notificationservice.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.notificationservice.dto.NotificationMessage;
+import org.example.notificationservice.entity.NotificationCondition;
+import org.example.notificationservice.entity.NotificationHistory;
+import org.example.notificationservice.repository.NotificationConditionRepository;
+import org.example.notificationservice.repository.NotificationHistoryRepository;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ConditionEvaluationService {
+    
+    private final NotificationConditionRepository conditionRepository;
+    private final NotificationHistoryRepository historyRepository;
+    private final NotificationProducerService notificationProducerService;
+    private final StockInfoService stockInfoService;
+    
+    // 조건 평가용 별도 스레드 풀
+    private final Executor evaluationExecutor = Executors.newFixedThreadPool(4);
+    
+    /**
+     * 특정 종목의 시세 데이터로 조건 평가
+     */
+    @Transactional
+    public void evaluateQuoteConditions(String stockCode, BigDecimal currentPrice, Long currentVolume, BigDecimal changeRate) {
+        try {
+            log.debug("Evaluating quote conditions for stock: {} - Price: {}, Volume: {}, Change: {}%", 
+                stockCode, currentPrice, currentVolume, changeRate);
+            
+            // 해당 종목의 활성화된 조건들 조회
+            List<NotificationCondition> conditions = conditionRepository.findByStockCodeAndIsActiveTrue(stockCode);
+            
+            if (conditions.isEmpty()) {
+                return;
+            }
+            
+            log.debug("Found {} active conditions for stock: {}", conditions.size(), stockCode);
+            
+            // 비동기로 조건 평가 처리
+            CompletableFuture.runAsync(() -> {
+                evaluateConditionsAsync(conditions, currentPrice, currentVolume, changeRate);
+            }, evaluationExecutor);
+            
+        } catch (Exception e) {
+            log.error("Error evaluating quote conditions for stock: {}", stockCode, e);
+        }
+    }
+    
+    /**
+     * 조건 평가 비동기 처리
+     */
+    private void evaluateConditionsAsync(List<NotificationCondition> conditions, BigDecimal currentPrice, Long currentVolume, BigDecimal changeRate) {
+        for (NotificationCondition condition : conditions) {
+            try {
+                evaluateSingleCondition(condition, currentPrice, currentVolume, changeRate);
+            } catch (Exception e) {
+                log.error("Error evaluating condition: {} for stock: {}", condition.getId(), condition.getStockCode(), e);
+            }
+        }
+    }
+    
+    /**
+     * 개별 조건 평가
+     */
+    @Transactional
+    public void evaluateSingleCondition(NotificationCondition condition, BigDecimal currentPrice, Long currentVolume, BigDecimal changeRate) {
+        // 조건 충족 여부 확인
+        boolean isConditionMet = condition.isConditionMet(currentPrice, currentVolume, changeRate);
+        
+        if (!isConditionMet) {
+            return;
+        }
+        
+        log.info("Condition triggered - ID: {}, User: {}, Stock: {}, Type: {}, Target: {}", 
+            condition.getId(), condition.getUserId(), condition.getStockCode(), 
+            condition.getConditionType(), condition.getTargetValue());
+        
+        // 조건 트리거 처리
+        BigDecimal triggeredValue = getTriggeredValue(condition.getConditionType(), currentPrice, currentVolume, changeRate);
+        condition.trigger(triggeredValue);
+        conditionRepository.save(condition);
+        
+        // 종목명 조회
+        String stockName = stockInfoService.getStockName(condition.getStockCode())
+            .orElse(condition.getStockCode());
+        
+        // 알림 메시지 생성
+        NotificationMessage notificationMessage = NotificationMessage.createPriceAlert(
+            condition.getUserId(),
+            condition.getStockCode(),
+            stockName,
+            condition.getConditionType(),
+            condition.getTargetValue(),
+            triggeredValue
+        );
+        
+        // 알림 이력 저장
+        NotificationHistory history = NotificationHistory.builder()
+            .userId(condition.getUserId())
+            .stockCode(condition.getStockCode())
+            .conditionId(condition.getId())
+            .conditionType(condition.getConditionType())
+            .targetValue(condition.getTargetValue())
+            .triggeredValue(triggeredValue)
+            .message(notificationMessage.getMessage())
+            .status(NotificationHistory.NotificationStatus.PENDING)
+            .build();
+        
+        NotificationHistory savedHistory = historyRepository.save(history);
+        notificationMessage.setNotificationId(savedHistory.getId());
+        
+        // Kafka로 알림 전송
+        notificationProducerService.sendNotification(notificationMessage);
+        
+        log.info("Notification sent for condition: {} - User: {}, Stock: {}", 
+            condition.getId(), condition.getUserId(), condition.getStockCode());
+    }
+    
+    /**
+     * 배치 조건 평가 (전체 활성 조건 대상)
+     */
+    @Transactional(readOnly = true)
+    public void evaluateAllConditionsBatch(int batchSize) {
+        try {
+            log.debug("Starting batch condition evaluation with batch size: {}", batchSize);
+            
+            int page = 0;
+            List<NotificationCondition> conditions;
+            
+            do {
+                conditions = conditionRepository.findActiveConditionsBatch(PageRequest.of(page, batchSize));
+                
+                if (!conditions.isEmpty()) {
+                    log.debug("Processing batch {} with {} conditions", page, conditions.size());
+                    
+                    // 종목별로 그룹화하여 처리
+                    conditions.stream()
+                        .collect(java.util.stream.Collectors.groupingBy(NotificationCondition::getStockCode))
+                        .forEach(this::evaluateStockConditions);
+                }
+                
+                page++;
+            } while (!conditions.isEmpty());
+            
+            log.debug("Batch condition evaluation completed");
+            
+        } catch (Exception e) {
+            log.error("Error in batch condition evaluation", e);
+        }
+    }
+    
+    /**
+     * 특정 종목의 조건들 평가
+     */
+    private void evaluateStockConditions(String stockCode, List<NotificationCondition> conditions) {
+        try {
+            // 최신 시세 정보 조회 (캐시 또는 DB에서)
+            var stockData = stockInfoService.getLatestStockData(stockCode);
+            
+            if (stockData.isPresent()) {
+                var data = stockData.get();
+                evaluateConditionsAsync(conditions, data.getPrice(), data.getVolume(), data.getChangeRate());
+            }
+            
+        } catch (Exception e) {
+            log.error("Error evaluating conditions for stock: {}", stockCode, e);
+        }
+    }
+    
+    /**
+     * 조건 타입에 따른 트리거된 값 추출
+     */
+    private BigDecimal getTriggeredValue(NotificationCondition.ConditionType conditionType, 
+                                       BigDecimal currentPrice, Long currentVolume, BigDecimal changeRate) {
+        switch (conditionType) {
+            case PRICE_ABOVE:
+            case PRICE_BELOW:
+                return currentPrice;
+            case VOLUME_ABOVE:
+                return currentVolume != null ? BigDecimal.valueOf(currentVolume) : BigDecimal.ZERO;
+            case CHANGE_RATE_ABOVE:
+            case CHANGE_RATE_BELOW:
+                return changeRate != null ? changeRate : BigDecimal.ZERO;
+            default:
+                return currentPrice;
+        }
+    }
+    
+    /**
+     * 조건 평가 통계 조회
+     */
+    public ConditionEvaluationStats getEvaluationStats() {
+        long totalActiveConditions = conditionRepository.countByIsActiveTrue();
+        long pendingNotifications = historyRepository.countByStatus(NotificationHistory.NotificationStatus.PENDING);
+        long sentNotifications = historyRepository.countByStatus(NotificationHistory.NotificationStatus.SENT);
+        long failedNotifications = historyRepository.countByStatus(NotificationHistory.NotificationStatus.FAILED);
+        
+        return ConditionEvaluationStats.builder()
+            .totalActiveConditions(totalActiveConditions)
+            .pendingNotifications(pendingNotifications)
+            .sentNotifications(sentNotifications)
+            .failedNotifications(failedNotifications)
+            .build();
+    }
+    
+    @lombok.Data
+    @lombok.Builder
+    public static class ConditionEvaluationStats {
+        private long totalActiveConditions;
+        private long pendingNotifications;
+        private long sentNotifications;
+        private long failedNotifications;
+    }
+}
+

--- a/notification-service/src/main/java/org/example/notificationservice/service/NotificationConditionService.java
+++ b/notification-service/src/main/java/org/example/notificationservice/service/NotificationConditionService.java
@@ -1,0 +1,170 @@
+package org.example.notificationservice.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.notificationservice.dto.CreateConditionRequest;
+import org.example.notificationservice.entity.NotificationCondition;
+import org.example.notificationservice.entity.NotificationHistory;
+import org.example.notificationservice.repository.NotificationConditionRepository;
+import org.example.notificationservice.repository.NotificationHistoryRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationConditionService {
+    
+    private final NotificationConditionRepository conditionRepository;
+    private final NotificationHistoryRepository historyRepository;
+    
+    /**
+     * 알림 조건 생성
+     */
+    @Transactional
+    public NotificationCondition createCondition(CreateConditionRequest request) {
+        NotificationCondition condition = request.toEntity();
+        
+        // 중복 조건 체크 (같은 사용자, 종목, 조건 타입, 목표값)
+        List<NotificationCondition> existingConditions = conditionRepository
+            .findByUserIdAndStockCodeOrderByCreatedAtDesc(request.getUserId(), request.getStockCode());
+        
+        boolean isDuplicate = existingConditions.stream()
+            .anyMatch(existing -> 
+                existing.getConditionType() == request.getConditionType() &&
+                existing.getTargetValue().compareTo(request.getTargetValue()) == 0 &&
+                existing.getIsActive()
+            );
+        
+        if (isDuplicate) {
+            throw new IllegalArgumentException("동일한 조건이 이미 존재합니다.");
+        }
+        
+        NotificationCondition savedCondition = conditionRepository.save(condition);
+        
+        log.info("Notification condition created - ID: {}, User: {}, Stock: {}, Type: {}, Target: {}", 
+            savedCondition.getId(), savedCondition.getUserId(), savedCondition.getStockCode(), 
+            savedCondition.getConditionType(), savedCondition.getTargetValue());
+        
+        return savedCondition;
+    }
+    
+    /**
+     * 사용자별 알림 조건 조회
+     */
+    @Transactional(readOnly = true)
+    public List<NotificationCondition> getUserConditions(String userId) {
+        return conditionRepository.findByUserIdOrderByCreatedAtDesc(userId);
+    }
+    
+    /**
+     * 사용자별 활성화된 알림 조건 조회
+     */
+    @Transactional(readOnly = true)
+    public List<NotificationCondition> getUserActiveConditions(String userId) {
+        return conditionRepository.findByUserIdAndIsActiveTrueOrderByCreatedAtDesc(userId);
+    }
+    
+    /**
+     * 알림 조건 수정
+     */
+    @Transactional
+    public NotificationCondition updateCondition(Long conditionId, CreateConditionRequest request) {
+        NotificationCondition condition = conditionRepository.findById(conditionId)
+            .orElseThrow(() -> new IllegalArgumentException("조건을 찾을 수 없습니다: " + conditionId));
+        
+        // 업데이트
+        condition.setConditionType(request.getConditionType());
+        condition.setTargetValue(request.getTargetValue());
+        condition.setDescription(request.getDescription());
+        
+        // 조건이 변경되었으므로 재활성화
+        if (!condition.getIsActive()) {
+            condition.reactivate();
+        }
+        
+        NotificationCondition savedCondition = conditionRepository.save(condition);
+        
+        log.info("Notification condition updated - ID: {}, Type: {}, Target: {}", 
+            savedCondition.getId(), savedCondition.getConditionType(), savedCondition.getTargetValue());
+        
+        return savedCondition;
+    }
+    
+    /**
+     * 알림 조건 삭제
+     */
+    @Transactional
+    public void deleteCondition(Long conditionId) {
+        NotificationCondition condition = conditionRepository.findById(conditionId)
+            .orElseThrow(() -> new IllegalArgumentException("조건을 찾을 수 없습니다: " + conditionId));
+        
+        conditionRepository.delete(condition);
+        
+        log.info("Notification condition deleted - ID: {}, User: {}, Stock: {}", 
+            conditionId, condition.getUserId(), condition.getStockCode());
+    }
+    
+    /**
+     * 알림 조건 활성화/비활성화 토글
+     */
+    @Transactional
+    public NotificationCondition toggleCondition(Long conditionId) {
+        NotificationCondition condition = conditionRepository.findById(conditionId)
+            .orElseThrow(() -> new IllegalArgumentException("조건을 찾을 수 없습니다: " + conditionId));
+        
+        if (condition.getIsActive()) {
+            condition.setIsActive(false);
+            log.info("Notification condition deactivated - ID: {}", conditionId);
+        } else {
+            condition.reactivate();
+            log.info("Notification condition reactivated - ID: {}", conditionId);
+        }
+        
+        return conditionRepository.save(condition);
+    }
+    
+    /**
+     * 사용자별 알림 이력 조회
+     */
+    @Transactional(readOnly = true)
+    public List<NotificationHistory> getUserNotificationHistory(String userId, Pageable pageable) {
+        return historyRepository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
+    }
+    
+    /**
+     * 종목별 알림 이력 조회
+     */
+    @Transactional(readOnly = true)
+    public List<NotificationHistory> getStockNotificationHistory(String stockCode) {
+        return historyRepository.findByStockCodeOrderByCreatedAtDesc(stockCode);
+    }
+    
+    /**
+     * 조건별 알림 이력 조회
+     */
+    @Transactional(readOnly = true)
+    public List<NotificationHistory> getConditionHistory(Long conditionId) {
+        return historyRepository.findByConditionIdOrderByCreatedAtDesc(conditionId);
+    }
+    
+    /**
+     * 사용자의 조건 수 조회
+     */
+    @Transactional(readOnly = true)
+    public long getUserConditionCount(String userId) {
+        return conditionRepository.findByUserIdAndIsActiveTrueOrderByCreatedAtDesc(userId).size();
+    }
+    
+    /**
+     * 종목별 조건 수 조회
+     */
+    @Transactional(readOnly = true)
+    public long getStockConditionCount(String stockCode) {
+        return conditionRepository.countActiveConditionsByStock(stockCode);
+    }
+}
+

--- a/notification-service/src/main/java/org/example/notificationservice/service/NotificationProducerService.java
+++ b/notification-service/src/main/java/org/example/notificationservice/service/NotificationProducerService.java
@@ -1,0 +1,144 @@
+package org.example.notificationservice.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.notificationservice.dto.NotificationMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationProducerService {
+    
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    
+    @Value("${app.kafka.topics.notification-alerts:notification-alerts}")
+    private String notificationTopic;
+    
+    /**
+     * 알림 메시지 Kafka 전송
+     */
+    public void sendNotification(NotificationMessage notification) {
+        try {
+            String messageJson = objectMapper.writeValueAsString(notification);
+            String key = generateMessageKey(notification);
+            
+            log.debug("Sending notification to Kafka - User: {}, Stock: {}, Type: {}", 
+                notification.getUserId(), notification.getStockCode(), notification.getConditionType());
+            
+            CompletableFuture<SendResult<String, String>> future = kafkaTemplate.send(notificationTopic, key, messageJson);
+            
+            future.thenAccept(result -> {
+                log.debug("Notification sent successfully - Offset: {}, Partition: {}", 
+                    result.getRecordMetadata().offset(), result.getRecordMetadata().partition());
+            }).exceptionally(throwable -> {
+                log.error("Failed to send notification - User: {}, Stock: {}", 
+                    notification.getUserId(), notification.getStockCode(), throwable);
+                return null;
+            });
+            
+        } catch (Exception e) {
+            log.error("Error serializing notification message - User: {}, Stock: {}", 
+                notification.getUserId(), notification.getStockCode(), e);
+        }
+    }
+    
+    /**
+     * 우선순위 기반 알림 전송
+     */
+    public void sendPriorityNotification(NotificationMessage notification) {
+        try {
+            // 우선순위가 높은 경우 별도 처리 (파티션 지정 등)
+            if (notification.getPriority() == NotificationMessage.Priority.URGENT) {
+                sendUrgentNotification(notification);
+            } else {
+                sendNotification(notification);
+            }
+            
+        } catch (Exception e) {
+            log.error("Error sending priority notification", e);
+        }
+    }
+    
+    /**
+     * 긴급 알림 전송 (특정 파티션 사용)
+     */
+    private void sendUrgentNotification(NotificationMessage notification) {
+        try {
+            String messageJson = objectMapper.writeValueAsString(notification);
+            String key = generateMessageKey(notification);
+            
+            // 긴급 알림은 특정 파티션(0번)으로 전송하여 우선 처리
+            int urgentPartition = 0;
+            
+            log.info("Sending URGENT notification - User: {}, Stock: {}", 
+                notification.getUserId(), notification.getStockCode());
+            
+            CompletableFuture<SendResult<String, String>> future = 
+                kafkaTemplate.send(notificationTopic, urgentPartition, key, messageJson);
+            
+            future.thenAccept(result -> {
+                log.info("Urgent notification sent - Offset: {}, Partition: {}", 
+                    result.getRecordMetadata().offset(), result.getRecordMetadata().partition());
+            }).exceptionally(throwable -> {
+                log.error("Failed to send urgent notification - User: {}, Stock: {}", 
+                    notification.getUserId(), notification.getStockCode(), throwable);
+                return null;
+            });
+            
+        } catch (Exception e) {
+            log.error("Error sending urgent notification", e);
+        }
+    }
+    
+    /**
+     * 배치 알림 전송
+     */
+    public void sendBatchNotifications(java.util.List<NotificationMessage> notifications) {
+        try {
+            log.debug("Sending batch notifications - Count: {}", notifications.size());
+            
+            for (NotificationMessage notification : notifications) {
+                sendNotification(notification);
+            }
+            
+            log.debug("Batch notifications sent successfully - Count: {}", notifications.size());
+            
+        } catch (Exception e) {
+            log.error("Error sending batch notifications", e);
+        }
+    }
+    
+    /**
+     * 메시지 키 생성 (사용자 ID 기반 파티셔닝)
+     */
+    private String generateMessageKey(NotificationMessage notification) {
+        return notification.getUserId() + ":" + notification.getStockCode();
+    }
+    
+    /**
+     * 알림 재전송 (실패한 알림 재시도용)
+     */
+    public void resendNotification(NotificationMessage notification, int retryCount) {
+        try {
+            log.info("Resending notification - User: {}, Stock: {}, Retry: {}", 
+                notification.getUserId(), notification.getStockCode(), retryCount);
+            
+            // 재전송 시 메타데이터 추가
+            notification.setNotificationId(notification.getNotificationId()); // ID 유지
+            
+            sendNotification(notification);
+            
+        } catch (Exception e) {
+            log.error("Error resending notification - Retry: {}", retryCount, e);
+        }
+    }
+}
+

--- a/notification-service/src/main/java/org/example/notificationservice/service/StockInfoService.java
+++ b/notification-service/src/main/java/org/example/notificationservice/service/StockInfoService.java
@@ -1,0 +1,55 @@
+package org.example.notificationservice.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.notificationservice.entity.Stock;
+import org.example.notificationservice.repository.StockRepository;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockInfoService {
+    
+    private final StockRepository stockRepository;
+    
+    /**
+     * 종목명 조회 (캐시 적용)
+     */
+    @Cacheable(value = "stockNames", key = "#stockCode")
+    public Optional<String> getStockName(String stockCode) {
+        return stockRepository.findByStockCode(stockCode)
+            .map(Stock::getStockName);
+    }
+    
+    /**
+     * 최신 주식 데이터 조회 (Mock 구현)
+     * 실제로는 data-processor 서비스나 캐시에서 조회해야 함
+     */
+    public Optional<StockData> getLatestStockData(String stockCode) {
+        // TODO: 실제로는 data-processor 서비스 호출 또는 캐시에서 조회
+        // 현재는 Mock 데이터 반환
+        log.debug("Getting latest stock data for: {} (Mock implementation)", stockCode);
+        
+        return Optional.of(StockData.builder()
+            .stockCode(stockCode)
+            .price(BigDecimal.valueOf(70000))
+            .volume(1000L)
+            .changeRate(BigDecimal.valueOf(1.5))
+            .build());
+    }
+    
+    @lombok.Data
+    @lombok.Builder
+    public static class StockData {
+        private String stockCode;
+        private BigDecimal price;
+        private Long volume;
+        private BigDecimal changeRate;
+    }
+}
+

--- a/notification-service/src/main/resources/application.yml
+++ b/notification-service/src/main/resources/application.yml
@@ -4,32 +4,61 @@ server:
 spring:
   application:
     name: notification-service
+  
+  # Database Configuration
   datasource:
-    url: jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/${MYSQL_DATABASE:stock_streaming}
-    username: stock_user
-    password: stock_pass
+    url: ${DB_URL:jdbc:mysql://localhost:3306/stock_streaming?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul}
+    username: ${DB_USERNAME:stock_user}
+    password: ${DB_PASSWORD:stock_pass}
     driver-class-name: com.mysql.cj.jdbc.Driver
     hikari:
       maximum-pool-size: 10
-      minimum-idle: 3
+      minimum-idle: 5
       connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+  
+  # JPA Configuration
   jpa:
     hibernate:
-      ddl-auto: none
-    show-sql: false
-    database-platform: org.hibernate.dialect.MySQLDialect
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+        show_sql: false
+    open-in-view: false
+  
+  # Kafka Configuration
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     consumer:
       group-id: notification-service-group
-      auto-offset-reset: earliest
+      auto-offset-reset: latest
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       enable-auto-commit: false
+      max-poll-records: 100
+      fetch-min-size: 1
+      fetch-max-wait: 500
+      properties:
+        session.timeout.ms: 30000
+        heartbeat.interval.ms: 3000
+        max.poll.interval.ms: 300000
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
+      acks: all
+      enable-idempotence: true
+      retries: 3
+      batch-size: 16384
+      linger-ms: 5
+      compression-type: snappy
+    listener:
+      ack-mode: manual_immediate
+      concurrency: 2
+      poll-timeout: 3000
 
+# Management & Monitoring
 management:
   endpoints:
     web:
@@ -38,10 +67,29 @@ management:
   endpoint:
     health:
       show-details: always
+  metrics:
+    export:
+      prometheus:
+        enabled: true
 
+# Logging Configuration
 logging:
   level:
     org.example.notificationservice: DEBUG
     org.springframework.kafka: INFO
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"
+
+# Application Specific Configuration
+app:
+  kafka:
+    topics:
+      quote-stream: quote-stream
+      orderbook-stream: orderbook-stream
+      notification-alerts: notification-alerts
+  
+  notification:
+    evaluation-interval: 1000    # 조건 평가 간격 (ms)
+    max-retry-attempts: 3        # 최대 재시도 횟수
+    retry-delay: 5000           # 재시도 간격 (ms)
+    batch-size: 100             # 배치 처리 크기


### PR DESCRIPTION
✦ 개요

  이 Pull Request는 사용자가 설정한 조건에 따라 실시간 주식 정보를 바탕으로 알림을
  생성하고 전송하는 notification-service를 신규로 구현합니다. 이를 통해 사용자에게
  맞춤형 정보를 적시에 제공하여 서비스의 가치와 사용자 참여를 높이는 데 중점을 둡니다.

  ✦ 주요 변경 사항

   1. 알림 조건 관리 기능
       * NotificationController를 통해 사용자가 알림 조건(목표가, 변동률 등)을 생성,
         조회, 수정, 삭제할 수 있는 REST API를 구현했습니다.
       * NotificationCondition 엔티티와 NotificationConditionRepository를 통해 사용자의
         알림 설정을 데이터베이스에 영속적으로 관리합니다.

   2. 실시간 조건 평가 및 알림 생성
       * QuoteStreamConsumer가 Kafka의 quote-stream 토픽을 구독하여 실시간 시세 데이터를
         수신합니다.
       * ConditionEvaluationService에서 수신된 데이터를 활성화된 모든 알림 조건과
         비교하여 충족 여부를 실시간으로 평가합니다.
       * 조건 충족 시, NotificationProducerService가 상세 내용을 담은 알림 메시지를
         생성하여 notification-alerts Kafka 토픽으로 전송합니다.

   3. 알림 전송 및 이력 관리
       * NotificationConsumer가 notification-alerts 토픽을 구독하여 최종 알림 메시지를
         수신하고 전송 로직을 처리합니다.
       * NotificationHistory 엔티티를 통해 발송된 모든 알림의 이력을 기록하여 추적 및
         관리가 가능하도록 했습니다.

   4. 독립 배포 구성
       * Dockerfile을 추가하여 notification-service를 독립적인 컨테이너 환경에서 배포할
         수 있도록 구성했습니다.

  ✦ 기대 효과

   * 사용자 경험 향상: 사용자는 더 이상 시장을 계속 주시하지 않아도 원하는 시점에 중요한
     정보를 알림으로 받을 수 있어 서비스 만족도가 향상됩니다.
   * 서비스 확장성 확보: 알림 생성과 전송 로직이 Kafka 메시지 큐를 통해 비동기적으로
     분리되어 있어, 향후 알림 채널(푸시, 이메일 등)을 유연하게 확장할 수 있습니다.
   * 시스템 안정성: 각 기능이 마이크로서비스 아키텍처에 따라 독립적으로 구현되어, 특정
     기능의 장애가 전체 시스템에 미치는 영향을 최소화합니다.
